### PR TITLE
Ensure that pods_to_remove aren't brought in recursively

### DIFF
--- a/lib/cocoapods-catalyst-support/pod/installer.rb
+++ b/lib/cocoapods-catalyst-support/pod/installer.rb
@@ -33,7 +33,7 @@ module Pod
       pod_names_to_keep = all_pods.filter do |name| !pod_names_to_remove.include? name end
       $verbose = (defined? podfile.debug) ? podfile.debug : $verbose
 
-      pod_names_to_keep = recursive_dependencies(pod_names_to_keep)
+      pod_names_to_keep = recursive_dependencies(pod_names_to_keep).filter do |name| !pod_names_to_remove.include? name end
       pod_targets_to_keep = pod_targets.filter do |pod| pod_names_to_keep.include? pod.module_name end       # PodTarget
 
       pod_names_to_remove = recursive_dependencies(pod_names_to_remove).filter do |name| !pod_names_to_keep.include? name end.to_set.to_a


### PR DESCRIPTION
If a target has a transitive dependency on a pod that should be removed, it should still be removed.

This fixes the following scenario where specifying a pod to be removed would have no effect:

```
target MyTarget
  pod 'MyKit', :path => 'Libraries/MyKit'
  pod 'MyiOSOnlyDep'
end

catalyst_configuration do
    ios 'MyiOSOnlyDep'
end

post_install do |installer|
    installer.configure_catalyst
end
```

MyKit.podspec:
```
Pod::Spec.new do |spec|
  spec.name = 'MyKit'
  …
  spec.dependency 'MyiOSOnlyDep'
end
```

Prior to this PR, `MyiOSOnlydep` would be linked on all platforms. After this change, it is only linked on iOS (not macCatalyst).